### PR TITLE
Recalculate position of elements on a page once the body height has changed

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,78 +1,72 @@
 /*global module*/
 
-module.exports = function(config) {
-	config.set({
+var oprions = {
+	// base path that will be used to resolve all patterns (eg. files, exclude)
+	basePath: '',
 
-		// base path that will be used to resolve all patterns (eg. files, exclude)
-		basePath: '',
+	// frameworks to use
+	// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+	frameworks: ['browserify', 'mocha'],
 
-		// frameworks to use
-		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-		frameworks: ['browserify', 'mocha'],
+	// list of files / patterns to load in the browser
+	files: [
+		'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
+		'test/*.test.js'
+	],
 
-		// list of files / patterns to load in the browser
-		files: [
-			'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
-			'test/*.test.js'
-		],
+	// list of files to exclude
+	exclude: [
+	],
 
-		// list of files to exclude
-		exclude: [
-		],
+	// preprocess matching files before serving them to the browser
+	// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+	preprocessors: {
+		'test/*.test.js': ['browserify']
+	},
 
-		// preprocess matching files before serving them to the browser
-		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-		preprocessors: {
-			'test/*.test.js': ['browserify']
-		},
+	// test results reporter to use
+	// possible values: 'dots', 'progress'
+	// available reporters: https://npmjs.org/browse/keyword/karma-reporter
+	reporters: ['progress'],
 
-		// test results reporter to use
-		// possible values: 'dots', 'progress'
-		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
-		reporters: ['progress'],
+	// web server port
+	port: 9876,
 
-		// web server port
-		port: 9876,
+	// enable / disable colors in the output (reporters and logs)
+	colors: true,
 
-		// enable / disable colors in the output (reporters and logs)
-		colors: true,
 
-		// level of logging
-		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-		logLevel: config.LOG_INFO,
+	// enable / disable watching file and executing tests whenever any file changes
+	autoWatch: true,
+	singleRun: false,
 
-		// enable / disable watching file and executing tests whenever any file changes
-		autoWatch: false,
+	browsers: ['Chrome'],
 
-		// start these browsers
-		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['PhantomJSCustom'],
+	// Continuous Integration mode
+	// if true, Karma captures browsers, runs the tests and exits
 
-		// change browser to PhantomJSDebug to launch the test with remote debugging enabled
-		customLaunchers: {
-			// this should set the viewport size of the browser
-			PhantomJSCustom: {
-				base: 'PhantomJS',
-				options: {
-					viewportSize: { width: 200, height: 500 }
-				}
-			},
-			PhantomJSDebug: {
-				base: 'PhantomJS',
-				options: {
-					viewportSize: { width: 200, height: 500 }
-				},
-				debug: true
+	browserify: {
+		debug: true,
+		transform: ['babelify', 'debowerify']
+	},
+
+	client: {
+			mocha: {
+					reporter: 'html',
+					ui: 'bdd',
+					timeout: 0
 			}
-		},
+	},
+};
 
-		// Continuous Integration mode
-		// if true, Karma captures browsers, runs the tests and exits
-		singleRun: true,
+if (process.env.CI) {
+  console.log('CI options on.');
+  options.browsers = ['PhantomJS'];
+  options.autoWatch = false;
+  options.singleRun = true;
+}
 
-		browserify: {
-			debug: true,
-			transform: ['babelify', 'debowerify']
-		}
-	});
+module.exports = function (config) {
+  options.logLevel = config.LOG_INFO;
+  config.set(options);
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,7 @@ var options = {
 
 	// frameworks to use
 	// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-	frameworks: ['browserify', 'mocha'],
+	frameworks: ['browserify', 'mocha', 'sinon'],
 
 	// list of files / patterns to load in the browser
 	files: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,7 @@
 /*global module, process*/
+/*eslint strict: 0, no-var: 0, no-console: 0 */
 
-let options = {
+var options = {
 	// base path that will be used to resolve all patterns (eg. files, exclude)
 	basePath: '',
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
-/*global module*/
+/*global module, process*/
 
-var options = {
+let options = {
 	// base path that will be used to resolve all patterns (eg. files, exclude)
 	basePath: '',
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 /*global module*/
 
-var oprions = {
+var options = {
 	// base path that will be used to resolve all patterns (eg. files, exclude)
 	basePath: '',
 

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const TrackedElement = require('./src/tracked-element');
 
 const tracked = [];
 let tracking = false;
+let bodyHeight = window.document.body.clientHeight;
 
 /*
 * begin tracking an element
@@ -51,6 +52,16 @@ function updatePositions(force) {
 }
 
 /*
+* Call the updateScrollHandler method when scrolling
+*/
+function updateScrollHandler() {
+	if(bodyHeight !== document.body.clientHeight) {
+		updatePositions();
+	}
+	update();
+}
+
+/*
 * initialise
 */
 function init(selector) {
@@ -77,7 +88,7 @@ function destroy() {
 	if (tracking === true) {
 		document.body.removeEventListener('oViewport.orientation', updatePositions);
 		document.body.removeEventListener('oViewport.resize', updatePositions);
-		document.body.removeEventListener('oViewport.scroll', update);
+		document.body.removeEventListener('oViewport.scroll', updateScrollHandler);
 		document.body.removeEventListener('oViewport.visibility', update);
 		tracking = false;
 	}
@@ -88,7 +99,7 @@ function initEvents() {
 		oViewport.listenTo('all');
 		document.body.addEventListener('oViewport.orientation', updatePositions);
 		document.body.addEventListener('oViewport.resize', updatePositions);
-		document.body.addEventListener('oViewport.scroll', update);
+		document.body.addEventListener('oViewport.scroll', updateScrollHandler);
 		document.body.addEventListener('oViewport.visibility', update);
 
 		tracking = true;

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const TrackedElement = require('./src/tracked-element');
 
 const tracked = [];
 let tracking = false;
-let bodyHeight = window.document.body.clientHeight;
+let bodyHeight = document.body.clientHeight;
 
 /*
 * begin tracking an element

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ function updatePositions(force) {
 function updateScrollHandler() {
 	if(bodyHeight !== document.body.clientHeight) {
 		updatePositions();
+		bodyHeight = document.body.clientHeight;
 	}
 	update();
 }

--- a/main.js
+++ b/main.js
@@ -56,8 +56,8 @@ function updatePositions(force) {
 */
 function updateScrollHandler() {
 	if(bodyHeight !== document.body.clientHeight) {
-		updatePositions();
 		bodyHeight = document.body.clientHeight;
+		updatePositions();
 	}
 	update();
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-chrome-launcher": "^0.2.2",
     "karma-junit-reporter": "^0.3.8",
+    "karma-sinon": "^1.0.4",
     "mocha": "^2.3.3",
     "lodash": "^3.10.1",
-    "babelify": "^6.0.3"
+    "babelify": "^6.0.3",
+    "sinon": "^1.17.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "devDependencies": {
     "debowerify": "^1.3.1",
     "expect.js": "^0.3.1",
-    "karma": "^0.13.10",
+    "karma": "^0.13.14",
     "karma-browserify": "^4.2.1",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-junit-reporter": "^0.3.8",
     "mocha": "^2.3.3",
     "lodash": "^3.10.1",
     "babelify": "^6.0.3"

--- a/test/element-visibility.test.js
+++ b/test/element-visibility.test.js
@@ -103,39 +103,39 @@ describe('o-element-visibility', function() {
 			let trackedElement = oElemVis.track(inview);
 			// spy on the update position
 			let trackedElementUpdatePositionSpy = sinon.spy(trackedElement, 'updatePosition');
-			// scroll few times
-			window.scroll(0,0);
-			window.scroll(0,1);
-			window.scroll(0,2);
+
 			expect(trackedElement.top).to.equal(0);
 			expect(trackedElement.inview).to.equal(true);
 			expect(trackedElementUpdatePositionSpy.callCount).to.equal(0);
 			// append DOM to add a new element
 			document.body.insertAdjacentHTML('afterbegin', '<div id="gap" style="width: 10px; height: '+height+'px; background: #ff0000;"></div>');
-			// fire scroll
-			window.scroll(0,10);
 
-			// give time to propagate the event
-			setTimeout(function(){
+			function assertFirst(){
 				// make sure tracked element position has been updated
 				expect(trackedElement.top).to.equal(height);
 				expect(trackedElement.inview).to.equal(false);
 				// make sure the recalculation has only been done once and not once for each scroll event
 				expect(trackedElementUpdatePositionSpy.callCount).to.equal(1);
-			}, 0);
+			}
 
-			// fire scroll
-			window.scroll(0,10);
-
-			// give time to propagate the event
-			setTimeout(function(){
+			function assertSecond(){
 				// make sure we did not call the updatePosition twice
 				expect(trackedElementUpdatePositionSpy.callCount).to.equal(1);
-				// cleanup
-				document.body.removeChild(document.getElementById('gap'));
-				trackedElementUpdatePositionSpy.restore();
 				done();
-			}, 0);
+			}
+
+			window.addEventListener('scroll', assertFirst);
+			window.dispatchEvent(new CustomEvent('scroll'));
+			window.removeEventListener('scroll', assertFirst);
+
+			window.addEventListener('scroll', assertSecond);
+			window.dispatchEvent(new CustomEvent('scroll'));
+			window.removeEventListener('scroll', assertSecond);
+
+			// test cleanup
+			document.body.removeChild(document.getElementById('gap'));
+			trackedElementUpdatePositionSpy.restore();
+
 		});
 	});
 

--- a/test/element-visibility.test.js
+++ b/test/element-visibility.test.js
@@ -74,7 +74,10 @@ describe('o-element-visibility', function() {
 
 		it('should report the outview element as 0% in viewport', function(done) {
 			// setting viewport size doesn't seem to work with karma/phantomjs so skip this test
-			if (isPhantom()) done();
+			if (isPhantom()) {
+				done();
+				return true;
+			}
 
 			function assert(event) {
 				expect(event.detail.inviewport).to.be(false);
@@ -92,7 +95,10 @@ describe('o-element-visibility', function() {
 
 		it('should recalculate the position of tracked elements once you scroll if height of body changed', function(done) {
 			// setting viewport size doesn't seem to work with karma/phantomjs so skip this test
-			if (isPhantom()) return true;
+			if (isPhantom()) {
+				done();
+				return true;
+			}
 
 			let trackedElement = oElemVis.track(inview);
 			// spy on the update position
@@ -116,6 +122,15 @@ describe('o-element-visibility', function() {
 				expect(trackedElement.inview).to.equal(false);
 				// make sure the recalculation has only been done once and not once for each scroll event
 				expect(trackedElementUpdatePositionSpy.callCount).to.equal(1);
+			}, 0);
+
+			// fire scroll
+			window.scroll(0,10);
+
+			// give time to propagate the event
+			setTimeout(function(){
+				// make sure we did not call the updatePosition twice
+				expect(trackedElementUpdatePositionSpy.callCount).to.equal(1);
 				// cleanup
 				document.body.removeChild(document.getElementById('gap'));
 				trackedElementUpdatePositionSpy.restore();
@@ -125,10 +140,14 @@ describe('o-element-visibility', function() {
 	});
 
 	describe('should fire events when visibility status changes', function() {
-		// setting viewport size doesn't seem to work with karma/phantomjs so skip this test
-		if (isPhantom()) return true;
 
 		it('should report the outview element as 100% and inview as 0% in viewport', function(done) {
+			// setting viewport size doesn't seem to work with karma/phantomjs so skip this test
+			if (isPhantom()) {
+				done();
+				return true;
+			}
+
 			let assertions = 0;
 			document.documentElement.addEventListener('oVisibility.inview', assertFirst);
 			oElemVis.track(inview);

--- a/test/element-visibility.test.js
+++ b/test/element-visibility.test.js
@@ -91,6 +91,9 @@ describe('o-element-visibility', function() {
 		});
 
 		it('should recalculate the position of tracked elements once you scroll if height of body changed', function(done) {
+			// setting viewport size doesn't seem to work with karma/phantomjs so skip this test
+			if (isPhantom()) return true;
+
 			let trackedElement = oElemVis.track(inview);
 			// spy on the update position
 			let trackedElementUpdatePositionSpy = sinon.spy(trackedElement, 'updatePosition');

--- a/test/element-visibility.test.js
+++ b/test/element-visibility.test.js
@@ -3,7 +3,6 @@ const expect = require('expect.js');
 const sinon = require('sinon');
 
 const oElemVis = require('./../main.js');
-const TrackedElement = require('./../src/tracked-element.js');
 
 function isPhantom() {
 	return /PhantomJS/.test(navigator.userAgent);
@@ -12,7 +11,7 @@ function isPhantom() {
 describe('o-element-visibility', function() {
 	let inview;
 	let outview;
-	let thirdPartyContainerMock;
+
 	const height = (window.innerHeight + 100);
 	beforeEach(function() {
 		document.body.style.height = height + 'px';


### PR DESCRIPTION
I have added code for module to take care when the elements get pushed down by other modules, relates to https://github.com/Financial-Times/ft-origami/issues/447

Idea for the PR is to take care of the issue until a decision is made on the event name.

Note although the code is attached to the scroll event, that scroll event is throttled in the oViewport module.

Also, we only ever recalculate the position of elements if the actual body height of the page has changed. 

/cc @AlbertoElias 
