### PR TITLE
Set the support status to "dead".

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Utility for tracking element visibility within the viewport.
 
+**o-element-visibility is deprecated. Instead use [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) with a [polyfill](http://polyfill.io/) to support browsers without Intersection Observer.**
+
 ## Methods
 
 ### `o-element-visibility#init(selector)`

--- a/origami.json
+++ b/origami.json
@@ -9,7 +9,7 @@
         "email": "origami.support@ft.com",
         "slack": "financialtimes/ft-origami"
     },
-    "supportStatus": "active",
+    "supportStatus": "dead",
     "browserFeatures": {
         "required": [
             "customevent",


### PR DESCRIPTION
We decided to skip the "deprecation" status as we are in the process
of removing `o-element-visibility` from the few places it is used
within internal products.